### PR TITLE
Add GitHub workflow to keep Streamlit app awake

### DIFF
--- a/.github/workflows/ping.yml
+++ b/.github/workflows/ping.yml
@@ -1,0 +1,14 @@
+name: Keep Site Awake
+
+on:
+  schedule:
+    - cron: '*/20 * * * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping the site
+        run: |
+          curl -s "https://wineagent.streamlit.app/" > /dev/null


### PR DESCRIPTION
- Added a new GitHub Action workflow (`.github/workflows/ping.yml`)
- Sends a ping to https://wineagent.streamlit.app/ every 20 minutes
- Purpose: Prevent the Streamlit app from going idle 
